### PR TITLE
Fix "UndefVarError: x not defined" in ndigits0z

### DIFF
--- a/src/int_ops.jl
+++ b/src/int_ops.jl
@@ -11,9 +11,9 @@ for S in (:SafeSigned, :SafeUnsigned)
     @inline one(x::T)  where T<:$S = one(T)
     @inline sizeof(x::T) where T<:$S = sizeof(T)
     @inline bitsof(x::T) where T<:$S = bitsof(T)
-    ndigits0z(n::T) where T<:$S = ndigits0z(baseint(x)) # do not reconvert
-    ndigits0z(n::T1, b::T2) where T1<:$S where T2<:SafeInteger = ndigits0z(baseint(x), baseint(b)) # do not reconvert
-    ndigits0z(n::T1, b::T2) where T1<:$S where T2<:Integer = ndigits0z(baseint(x), b) # do not reconvert
+    ndigits0z(x::T) where T<:$S = ndigits0z(baseint(x)) # do not reconvert
+    ndigits0z(x::T1, b::T2) where T1<:$S where T2<:SafeInteger = ndigits0z(baseint(x), baseint(b)) # do not reconvert
+    ndigits0z(x::T1, b::T2) where T1<:$S where T2<:Integer = ndigits0z(baseint(x), b) # do not reconvert
     @inline count_zeros(x::T) where T<:$S = safeint(count_zeros(baseint(x)))
     @inline count_ones(x::T) where T<:$S = safeint(count_ones(baseint(x)))
     @inline leading_zeros(x::T) where T<:$S = safeint(leading_zeros(baseint(x)))


### PR DESCRIPTION
While trying to compose Interpolations.jl and SaferIntegers, I ran into this issue:

```julia
julia> itpi = LinearInterpolation(SafeInt[1,10000],SafeInt[1,10000]; extrapolation_bc=Line())
ERROR: UndefVarError: x not defined
Stacktrace:
  [1] ndigits0z(n::SafeInt64, b::Int64)
    @ SaferIntegers ~\.julia\packages\SaferIntegers\nOUgY\src\int_ops.jl:16
  [2] hash(x::SafeInt64, h::UInt64)
    @ Base .\float.jl:516
```

It seems to be a simple typo.