### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,9 @@ There are security implications for integer overflow in certain situations.
 
 - This package is designed for easy use and written to be performant in many sorts of use.
 
-- All exported types are stable (e.g. `typeof(SafeInt32 + 1) == SafeInt32`)
+- All exported types are stable (e.g. `typeof(SafeInt32(1) + 1) == SafeInt32`)
 
 - Using _SaferIntegers_ can preclude some known ways that insecure systems are breached.
-
-- Safer Rationals just work: `SafeRational(161803398875,100000000000)`
 
 ### Test code for integer safety
 
@@ -103,7 +101,6 @@ should a calculation encouter an overflow or underflow,
     - `abs`, `neg`, `div`, `fld`, `fld1`, `cld`, `rem`, `mod`, `mod1`
     - `divrem`, `fldmod`, `fldmod1`
     - `-`, `+`, `*`, `^`
-    - so does `/`, before converting to Float64
 
 ## Exported Types and Constructors / Converters
 
@@ -127,9 +124,9 @@ const SafeInteger = Union{SafeUnsigned, SafeSigned}
 
 ## Other Conversions 
 
-`Signed(x::SafeSigned)` returns an signed integer of the same bitwidth as x    
-`Unsigned(x::SafeUnsigned)` returns an unsigned integer of the same bitwidth as x    
-`Integer(x::SafeInteger)` returns an Integer of the same bitwidth and either Signed or Unsigned as is x
+`Signed(x::SafeSigned)` returns an signed built-in integer of the same bitwidth as x    
+`Unsigned(x::SafeUnsigned)` returns an unsigned built-in integer of the same bitwidth as x    
+`Integer(x::SafeInteger)` returns a built-in integer of the same bitwidth and either Signed or Unsigned as is x
 
 `SafeSigned(x::Signed)` returns a safe signed integer of the same bitwidth as x    
 `SafeUnsigned(x::Unsigned)` returns a safe unsigned integer of the same bitwidth as x    


### PR DESCRIPTION
The first change fixes a syntax error
```julia
julia> typeof(SafeInt32 + 1) == SafeInt32
ERROR: MethodError: no method matching +(::Type{SafeInt32}, ::Int64)

Closest candidates are:
  +(::Any, ::Any, ::Any, ::Any...)
   @ Base operators.jl:578
  +(::T, ::T) where T<:Union{Int128, Int16, Int32, Int64, Int8, UInt128, UInt16, UInt32, UInt64, UInt8}
   @ Base int.jl:87
  +(::LinearAlgebra.UniformScaling, ::Number)
   @ LinearAlgebra ~/.julia/dev/julia/usr/share/julia/stdlib/v1.9/LinearAlgebra/src/uniformscaling.jl:144
  ...

Stacktrace:
 [1] top-level scope
   @ REPL[32]:1

julia> typeof(SafeInt32(1) + 1) == SafeInt32
true
```

The second and third changes remove claims that falsely imply the unsafety of default integers.

Rationals are already checked for overflow:
```julia
help?> Rational
search: Rational rationalize Irrational SafeRational AbstractIrrational ConcurrencyViolationError ProcessFailedException

  Rational{T<:Integer} <: Real

  Rational number type, with numerator and denominator of type T. Rationals are checked for overflow.
```
SaferIntegers uses `Base.checked_div` instead of `Base.div`, but this is a no-op:
```julia
julia> @less Base.checked_div(7, 8)
checked_div(x::T, y::T) where {T<:Integer} = div(x, y) # Base.div already checks
...
```

The fourth change clarifies that the return type is a `BitInteger`, not an `UnsafeInteger` (`UnsafeSigned <: Integer`, so this is otherwise ambiguous)