### PR TITLE
Fix type parameter in exponentiation

### DIFF
--- a/src/pow.jl
+++ b/src/pow.jl
@@ -47,6 +47,6 @@ for (T,A,I) in ((:SafeInt128, :maxpowInt128, :Int128), (:SafeInt64, :maxpowInt64
   end
 end
 
-Base.:(^)(x::S1, y::S1) where {S1<:SafeInteger, S2<:SafeInteger} = (^)(promote(x,y)...,)
+Base.:(^)(x::S1, y::S2) where {S1<:SafeInteger, S2<:SafeInteger} = (^)(promote(x,y)...,)
 Base.:(^)(x::S, y::T) where {S<:SafeInteger, T<:Base.BitInteger} = (^)(promote(x,y)...,)
 Base.:(^)(x::T, y::S) where {T<:Base.BitInteger, S<:SafeInteger} = baseint((^)(promote(safeint(x), y)...))


### PR DESCRIPTION
I think this is the intended behavior, as the type parameter `S2` was unused otherwise.