### PR TITLE
Fix fail of @saferintegers with ^ operator

### DIFF
--- a/src/SaferIntTypes.jl
+++ b/src/SaferIntTypes.jl
@@ -78,10 +78,7 @@ end
 
 
 function changetypes(ex::Expr)
-    if Meta.isexpr(ex, :call, 3) && ex.args[1] == :^ && ex.args[3] isa Int
-        # mimic Julia 0.6/0.7's lowering to literal_pow
-        return Expr(:call, ChangeType.literal_pow, :^, changetype(ex.args[2]), Val{ex.args[3]}())
-    elseif Meta.isexpr(ex, :call, 2) && ex.args[1] == :include
+    if Meta.isexpr(ex, :call, 2) && ex.args[1] == :include
         return :($include(@__MODULE__, $(ex.args[2])))
     elseif Meta.isexpr(ex, :call) && ex.args[1] in changefuncs
         return Expr(:call, Core.eval(SaferIntTypes, ex.args[1]), changetype.(ex.args[2:end])...)


### PR DESCRIPTION
I admit that I'm not understanding very well how the package works but it seems that these changes should fix the problem in #35  with the ^ operator, let me know if this fix is unacceptable for whatever reason :-)

Now all seems to work fine:

```julia
julia> @saferintegers 100^1
100

julia> @saferintegers 2^62
4611686018427387904

julia> @saferintegers 2^63
ERROR: OverflowError: 2^63
Stacktrace:
 [1] ^(x::SafeInt64, y::SafeInt64)
   @ SaferIntegers ~/.julia/packages/SaferIntegers/Xn8ie/src/pow.jl:26
 [2] top-level scope
   @ REPL[16]:1
```

